### PR TITLE
Improve secret handling

### DIFF
--- a/app/serve.py
+++ b/app/serve.py
@@ -61,7 +61,7 @@ class SlackApp:
 ray.init(
     runtime_env={
         "env_vars": {
-            "DB_CONNECTION_STRING": DB_CONNECTION_STRING,
+            "DB_CONNECTION_STRING": get_secret("DB_CONNECTION_STRING"),
             "OPENAI_API_KEY": OPENAI_API_KEY,
         }
     },

--- a/app/serve.py
+++ b/app/serve.py
@@ -19,13 +19,29 @@ from app.config import (
     SLACK_BOT_TOKEN,
 )
 
+
+def get_secret(secret_name):
+    aws_secret_id = os.environ.get("RAY_ASSISTANT_AWS_SECRET_ID")
+    if aws_secret_id:
+        import boto3
+        client = boto3.client(
+            "secretsmanager", region_name=os.environ["RAY_ASSISTANT_AWS_REGION"]
+        )
+        response = client.get_secret_value(SecretId=aws_secret_id)
+        return json.loads(response["SecretString"])[secret_name]
+    else:
+        raise NotImplemented(
+            "Currently only AWS is supported "
+            "and you need to set RAY_ASSISTANT_AWS_SECRET_ID")
+
+
 app = FastAPI()
 
 
 @ray.remote
 class SlackApp:
     def __init__(self):
-        slack_app = App(token=os.environ["SLACK_BOT_TOKEN"])
+        slack_app = App(token=get_secret("SLACK_BOT_TOKEN"))
 
         @slack_app.event("app_mention")
         def event_mention(body, say):
@@ -39,7 +55,7 @@ class SlackApp:
         self.slack_app = slack_app
 
     def run(self):
-        SocketModeHandler(self.slack_app, SLACK_APP_TOKEN).start()
+        SocketModeHandler(self.slack_app, get_secret("SLACK_APP_TOKEN")).start()
 
 
 ray.init(
@@ -47,8 +63,6 @@ ray.init(
         "env_vars": {
             "DB_CONNECTION_STRING": DB_CONNECTION_STRING,
             "OPENAI_API_KEY": OPENAI_API_KEY,
-            "SLACK_APP_TOKEN": SLACK_APP_TOKEN,
-            "SLACK_BOT_TOKEN": SLACK_BOT_TOKEN,
         }
     },
     ignore_reinit_error=True,

--- a/app/service.yaml
+++ b/app/service.yaml
@@ -1,6 +1,11 @@
 name: "ray-assistant"
-cluster_env: ray-assistant
+cluster_env: ray-assistant:2
 ray_serve_config:
   import_path: app.serve:deployment
   runtime_env:
-    working_dir: "https://github.com/ray-project/llm-applications/archive/refs/tags/v0.0.1.zip"
+    working_dir: "https://github.com/ray-project/llm-applications/archive/refs/tags/v0.0.2.zip"
+    env_vars: {
+      DB_CONNECTION_STRING: "dbname=postgres user=postgres host=localhost password=postgres",
+      RAY_ASSISTANT_AWS_SECRET_ID: "ray-assistant",
+      RAY_ASSISTANT_AWS_REGION: "us-west-2"
+    }

--- a/app/service.yaml
+++ b/app/service.yaml
@@ -5,7 +5,6 @@ ray_serve_config:
   runtime_env:
     working_dir: "https://github.com/ray-project/llm-applications/archive/refs/tags/v0.0.2.zip"
     env_vars: {
-      DB_CONNECTION_STRING: "dbname=postgres user=postgres host=localhost password=postgres",
       RAY_ASSISTANT_AWS_SECRET_ID: "ray-assistant",
       RAY_ASSISTANT_AWS_REGION: "us-west-2"
     }


### PR DESCRIPTION
Use AWS secret manager to store secrets. The best way to set this up is by attaching the right role to the AWS instance.