### PR TITLE
Add structured logging for query outputs and update service

### DIFF
--- a/rag/generate.py
+++ b/rag/generate.py
@@ -76,9 +76,10 @@ def get_sources_and_context(query, embedding_model, num_chunks):
                 (embedding, num_chunks),
             )
             rows = cur.fetchall()
+            document_ids = [row[0] for row in rows]
             context = [{"text": row[1]} for row in rows]
             sources = [row[2] for row in rows]
-    return sources, context
+    return document_ids, sources, context
 
 
 class QueryAgent:
@@ -107,7 +108,7 @@ class QueryAgent:
 
     def __call__(self, query, num_chunks=5, stream=True):
         # Get sources and context
-        sources, context = get_sources_and_context(
+        document_ids, sources, context = get_sources_and_context(
             query=query, embedding_model=self.embedding_model, num_chunks=num_chunks
         )
 
@@ -126,6 +127,7 @@ class QueryAgent:
         result = {
             "question": query,
             "sources": sources,
+            "document_ids": document_ids,
             "answer": answer,
             "llm": self.llm,
         }

--- a/rag/serve.py
+++ b/rag/serve.py
@@ -1,5 +1,5 @@
 # You can run the whole script locally with
-# serve run rag.serve:deployment --runtime-env-json='{"env_vars": {"RAY_ASSISTANT_LOGS": "/mnt/shared_storage/ray-assistant-logs/info.log"}}'
+# serve run rag.serve:deployment --runtime-env-json='{"env_vars": {"RAY_ASSISTANT_LOGS": "/mnt/shared_storage/ray-assistant-logs/info.log", "RAY_ASSISTANT_SECRET": "ray-assistant-prod"}}'
 
 import json
 import logging
@@ -39,7 +39,7 @@ def get_secret(secret_name):
     import boto3
 
     client = boto3.client("secretsmanager", region_name="us-west-2")
-    response = client.get_secret_value(SecretId="ray-assistant")
+    response = client.get_secret_value(SecretId=os.environ["RAY_ASSISTANT_SECRET"])
     return json.loads(response["SecretString"])[secret_name]
 
 
@@ -165,7 +165,7 @@ class RayAssistantDeployment:
 
 # Deploy the Ray Serve app
 deployment = RayAssistantDeployment.bind(
-    num_chunks=7,
+    num_chunks=5,
     embedding_model_name="thenlper/gte-large",
     llm="meta-llama/Llama-2-70b-chat-hf",
 )

--- a/rag/service.yaml
+++ b/rag/service.yaml
@@ -3,4 +3,7 @@ cluster_env: ray-assistant
 ray_serve_config:
   import_path: app.serve:deployment
   runtime_env:
-    working_dir: "https://github.com/ray-project/llm-applications/archive/refs/tags/v0.0.8.zip"
+    working_dir: "https://github.com/ray-project/llm-applications/archive/refs/tags/v0.0.9.zip"
+    env_vars:
+      RAY_ASSISTANT_SECRET: "ray-assistant-prod"
+      RAY_ASSISTANT_LOGS: "/mnt/shared_storage/ray-assistant-logs/info.log"

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ ray
 sentence_transformers
 slack_bolt
 streamlit
+structlog
 typer
 tiktoken
 


### PR DESCRIPTION
This PR adds logging for the query outputs, so we know which documents were fed into the context, which model was used and which answer was returned to the user. Structured logging allows us to parse the logs later and extract the information we are interested in.