### PR TITLE
Fix "429 Too Many Requests" errors for wget

### DIFF
--- a/notebooks/rag.ipynb
+++ b/notebooks/rag.ipynb
@@ -401,7 +401,7 @@
     "export EFS_DIR=/desired/output/directory\n",
     "wget -e robots=off --recursive --no-clobber --page-requisites \\\n",
     "  --html-extension --convert-links --restrict-file-names=windows \\\n",
-    "  --domains docs.ray.io --no-parent --accept=html \\\n",
+    "  --domains docs.ray.io --no-parent --accept=html --wait 10 --random-wait \\\n",
     "  -P $EFS_DIR https://docs.ray.io/en/master/\n",
     "```"
    ]


### PR DESCRIPTION
If I'm running wget on a fast disk, it downloads faster than the server can keep up with. This makes it so wget will wait a little between requests if that's the case.