### PR TITLE
Revert "Fix "429 Too Many Requests" errors for wget"

### DIFF
--- a/notebooks/rag.ipynb
+++ b/notebooks/rag.ipynb
@@ -401,7 +401,7 @@
     "export EFS_DIR=/desired/output/directory\n",
     "wget -e robots=off --recursive --no-clobber --page-requisites \\\n",
     "  --html-extension --convert-links --restrict-file-names=windows \\\n",
-    "  --domains docs.ray.io --no-parent --accept=html --wait 10 --random-wait \\\n",
+    "  --domains docs.ray.io --no-parent --accept=html \\\n",
     "  -P $EFS_DIR https://docs.ray.io/en/master/\n",
     "```"
    ]


### PR DESCRIPTION
Reverts ray-project/llm-applications#87

`--wait` actually waits _on every request_, not only the failed ones, so is not what we want. It seems by default wget is already doing the right thing, but maybe a little too agressive in retries on 429 errors.