### PR TITLE
Add --retry-on-http-error=429 flag to wget

### DIFF
--- a/notebooks/rag.ipynb
+++ b/notebooks/rag.ipynb
@@ -401,7 +401,7 @@
     "export EFS_DIR=/desired/output/directory\n",
     "wget -e robots=off --recursive --no-clobber --page-requisites \\\n",
     "  --html-extension --convert-links --restrict-file-names=windows \\\n",
-    "  --domains docs.ray.io --no-parent --accept=html \\\n",
+    "  --domains docs.ray.io --no-parent --accept=html --retry-on-http-error=429 \\\n",
     "  -P $EFS_DIR https://docs.ray.io/en/master/\n",
     "```"
    ]


### PR DESCRIPTION
This is the right fix for what I was attempting in https://github.com/ray-project/llm-applications/pull/87 and https://github.com/ray-project/llm-applications/pull/88

It will retry the download when getting a `429 Too Many Requests` error.